### PR TITLE
Added Operation Context and Operation Error Context

### DIFF
--- a/SwiftOpsExample/UserPostCell.swift
+++ b/SwiftOpsExample/UserPostCell.swift
@@ -15,7 +15,7 @@ class UserPostTableViewCell : UITableViewCell {
     @IBOutlet var titleLabel:UILabel!
     @IBOutlet var bodyLabel:UILabel!
     
-    var imageOperationToken:CancelToken?
+    var imageOperationContext: OperationContext?
     
     override func prepareForReuse() {
         userImageView.image = nil

--- a/SwiftOpsExample/ViewController.swift
+++ b/SwiftOpsExample/ViewController.swift
@@ -45,14 +45,14 @@ extension UserPostTableViewCell {
     func populateFromViewModel(viewModel:PostViewModel) {
 
         // In case this cell is being reused while still donwloading an image for a previous user, cancel the previous download operation
-        imageOperationToken?.cancel()
+        imageOperationContext?.cancel()
                 
         usernameLabel.text = viewModel.username
         titleLabel.text = viewModel.title
         bodyLabel.text = viewModel.body
         
         // Save this as a cancelable operation so if this cell is reused before the image is downloaded, we can cancel the previous download operation and just run the new one
-        imageOperationToken = User.Operations.userPortraitImageFromNameString.start(withInput:viewModel.username) {
+        imageOperationContext = User.Operations.userPortraitImageFromNameString.start(withInput:viewModel.username) {
             do {
                 self.userImageView.image = try $0()
             } catch {

--- a/SwiftOpsExampleTests/UserTests.swift
+++ b/SwiftOpsExampleTests/UserTests.swift
@@ -14,7 +14,7 @@ class UserTests: XCTestCase {
     func testUserPortraitURLFromName() {
         let input = "Pat Kline"
         let expected = "https://robohash.org/PatKline"
-        XCTAssertEqual(User.operations.userPortraitURLFromNameString.value(forInput:input), expected)
+        XCTAssertEqual(User.Operations.userPortraitURLFromNameString.value(forInput:input), expected)
     }
     
     


### PR DESCRIPTION
- OperationContext returned for every run on an Operation (instead of simple cancel token).  Allows for cancellation of the Operation in-flight, setting a timeout interval for the Operation and access to the start date of the Operation
- Adds a method on Operations called ‘ifError’ which accepts an error handler.  This handler closure is passed an OperationErrorContext which allows it to inspect the error, and retry the operation with the same or a new input, or pass on the failure to the completion callback with either the original error or a new error.